### PR TITLE
Potential fix for code scanning alert no. 431: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -39,7 +39,7 @@ function runTest(clientsOptions, serverOptions, cb) {
     const opt = options.shift();
     opt.port = server.address().port;
     opt.host = serverIP;
-    opt.rejectUnauthorized = false;
+    opt.ca = loadPEM('agent2-cert');
 
     results[clientIndex] = {};
 


### PR DESCRIPTION
Potential fix for [https://github.com/cogpy/nodecog/security/code-scanning/431](https://github.com/cogpy/nodecog/security/code-scanning/431)

The best way to fix this problem is to avoid disabling certificate validation and only allow trusted certificates to be verified. Since this is a test scenario using local test certificates, you should instead specify the CA certificate to trust explicitly in the client options (`ca` field), rather than setting `rejectUnauthorized` to false. 

In this file:
- Remove `opt.rejectUnauthorized = false;` from `connectClient`.
- Set `opt.ca = loadPEM('agent2-cert');` to trust the certificate used by the server.

No further code changes or dependencies are required. If more certificates are relevant (e.g., separate CA or chain), include those in the `ca` option. 

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
